### PR TITLE
Rational numbers are Q, not Z

### DIFF
--- a/src/lib/expressions.ts
+++ b/src/lib/expressions.ts
@@ -147,7 +147,7 @@ export const expressions: Expression[] = [
   },
   {
     name: "Rational numbers",
-    formula: `\\mathbb{Z}`,
+    formula: `\\mathbb{Q}`,
     search: "",
     tags: [Category.Logic, Category.SetTheory],
   },


### PR DESCRIPTION
Fixes a small bug in the expressions list that lists rational numbers as $Z$ instead of $Q$.